### PR TITLE
Make the build fail when spelling errors detected.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,7 @@ test: spell proof
 # Spell check the source files.
 spell:
 	@command -v hunspell >/dev/null 2>&1 || { echo >&2 "hunspell required for spell testing."; exit 1; }
-	@echo "Checking spelling..."
-	@find . -name "*.adoc" -exec hunspell -d _dicts/buddybuild,_dicts/en_US -l '{}' \; | sort -u | grep . && (echo "^ Fix these spelling errors!" && exit 1) || exit 0;
-	@echo "No spelling errors found!"
+	@_tools/spellcheck.pl -d . -D _dicts
 
 # Run htmlproofer on the artifacts to catch bad images, links, etc.
 proof: all

--- a/_dicts/buddybuild.dic
+++ b/_dicts/buddybuild.dic
@@ -1,4 +1,5 @@
-366
+368
+10a
 13b
 1a
 2FA
@@ -246,6 +247,7 @@ kotlin
 launchOptions
 lineNumber
 linkattrs
+loweralpha
 lt
 m2repository
 md

--- a/_tools/spellcheck.pl
+++ b/_tools/spellcheck.pl
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 
-use Data::Dumper;
 use File::Spec::Functions;
 use Getopt::Std;
 
@@ -52,7 +51,6 @@ foreach my $key (sort keys %$results) {
   }
 }
 exit 1;
-
 
 sub findadoc {
   my $dir = shift;

--- a/_tools/spellcheck.pl
+++ b/_tools/spellcheck.pl
@@ -1,0 +1,120 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+use File::Spec::Functions;
+use Getopt::Std;
+
+our %options;
+getopts('hvd:D:', \%options);
+
+usage() if $options{h};
+
+our $VERBOSE = $options{v} ? 1 : 0;
+sub DEBUG {
+  return unless $VERBOSE;
+  print $_ for @_;
+}
+
+my $dir = $options{d} or usage("No scan directory provided!");
+our $dicts = $options{D} or usage("No dictionary path provided!");
+
+my $bbdict = catfile($dicts, 'buddybuild');
+my $usdict = catfile($dicts, 'en_US');
+our $hunspell_command = "hunspell -d $bbdict,$usdict -l";
+
+print "Checking spelling in '$dir'...\n";
+our @files = findadoc($dir);
+DEBUG "File scanning complete.\n\n";
+my $results = check_spelling(@files);
+
+unless (scalar keys %$results) {
+  print "No spelling errors found!\n";
+  exit 0;
+}
+
+print "Spelling errors found!\n";
+my $max = 0;
+foreach my $key (keys %$results) {
+  my $l = length $key;
+  $max = $l if $l > $max;
+}
+my $indent = " " x $max;
+
+foreach my $key (sort keys %$results) {
+  my $label = sprintf "%". $max ."s", $key;
+  my $result = $results->{$key};
+  foreach my $path (sort keys $result) {
+    printf "%s  %2dx %s\n", $label, $result->{$path}, $path;
+    $label = $indent;
+  }
+}
+exit 1;
+
+
+sub findadoc {
+  my $dir = shift;
+
+  my @files;
+  DEBUG "Scanning '$dir'...\n";
+  opendir(my $dh, $dir)
+    or die "Cannot open directory '$dir': $!\n";
+
+  while (my $file = readdir $dh) {
+    next if $file eq '.';
+    next if $file eq '..';
+
+    my $path = catfile($dir, $file);
+    if (-d $path) {
+      push @files, findadoc($path);
+      next;
+    }
+    next unless $file =~ m/\.adoc$/;
+    DEBUG "Found '$path'\n";
+    push @files, $path;
+  }
+
+  closedir $dh;
+  return @files;
+}
+
+sub check_spelling {
+  my %results;
+  foreach my $file (@_) {
+    DEBUG "Checking spelling in '$file'...\n";
+    my $command = $hunspell_command ." ". $file;
+    my $output = `$command`;
+    next unless length $output;
+    foreach my $line (split m/\n/, $output) {
+      DEBUG "Bad spelling '$line'\n";
+      $results{$line} = {} unless exists $results{$line};
+      $results{$line}->{$file} = 0 unless exists $results{$line}->{$file};
+      $results{$line}->{$file}++;
+    }
+  }
+  DEBUG "Done checking spelling.\n";
+  return \%results;
+}
+
+sub usage {
+  my $msg = shift;
+
+  print "ERROR: $msg\n\n" if $msg;
+  print <<USAGE;
+Usage:
+$0 [-hv] -d <directory to scan> -D <path to dictionaries>
+
+Scans a directory for '*.adoc' files, runs the hunspell spellcheck tool
+on each, and emits any spelling errors detected (exit code 1, if so).
+
+Options:
+ -h  This help text.
+ -d  The directory to scan.
+ -D  The path to the hunspell dictionaries.
+ -v  Verbose output.
+USAGE
+
+  exit $msg ? 1 : 0;
+}


### PR DESCRIPTION
Also, remove the book targets; they weren't catching everything.
Instead, always build the book from scratch.

Added the 'proofx' target, in case you need to check external
links locally (not intended for automated builds).