### PR TITLE
More line length fixes, for links/images that can be wrapped.

### DIFF
--- a/SUMMARY.adoc
+++ b/SUMMARY.adoc
@@ -9,13 +9,15 @@
 .. link:quickstart/bitbucket.adoc[Sign up with Bitbucket]
 .. link:quickstart/bitbucket_server.adoc[Connect with Bitbucket Server]
 .. link:quickstart/github_enterprise.adoc[Connect with GitHub Enterprise]
-.. link:quickstart/gitlab_private.adoc[Connect your privately-hosted GitLab instance]
+.. link:quickstart/gitlab_private.adoc[Connect your privately-hosted
+   GitLab instance]
 
 .. link:quickstart/ios/README.adoc[iOS]
 ... link:quickstart/ios/select_a_repo_and_app_to_build.adoc[Selecting an App]
 ... link:quickstart/ios/invite_testers.adoc[Inviting Testers]
 ... link:quickstart/ios/integrate_sdk.adoc[Integrating SDK]
-... link:quickstart/ios/apple_developer_portal_sync.adoc[Auto-Syncing Provisioning Profiles]
+... link:quickstart/ios/apple_developer_portal_sync.adoc[Auto-Syncing
+    Provisioning Profiles]
 ... link:quickstart/ios/auto_versioning.adoc[Auto Versioning]
 
 .. link:quickstart/android/README.adoc[Android]
@@ -55,7 +57,8 @@
 
 .. link:builds/frameworks/README.adoc[Cross-platform frameworks]
 ... link:builds/frameworks/react_native/README.adoc[React Native]
-.... link:builds/frameworks/react_native/log_javascript.adoc[Log JavaScript using the buddybuild SDK (iOS)]
+.... link:builds/frameworks/react_native/log_javascript.adoc[Log
+     JavaScript using the buddybuild SDK (iOS)]
 ... link:builds/frameworks/cordova-ionic/README.adoc[Cordova / Ionic]
 ... link:builds/frameworks/meteor/README.adoc[Meteor]
 
@@ -65,7 +68,8 @@
 .. link:builds/environment_variables.adoc[Environment Variables]
 .. link:builds/secure_files.adoc[Secure Files]
 .. link:builds/node.adoc[Node version]
-.. link:builds/provisioning_profile_explorer.adoc[Provisioning Profile Inspector]
+.. link:builds/provisioning_profile_explorer.adoc[Provisioning Profile
+   Inspector]
 .. link:builds/pull_requests.adoc[Pull Requests]
 .. link:builds/schedule_builds.adoc[Scheduling Builds]
 .. link:builds/skip_a_build.adoc[Skipping a Build]
@@ -82,7 +86,8 @@
 .. link:tests/ios/README.adoc[iOS]
 ... link:tests/ios/tests.adoc[Unit Tests]
 ... link:tests/ios/code_coverage.adoc[Code Coverage]
-... link:tests/ios/configure_ui_tests_video_recording.adoc[Configure UI tests for Video Replay]
+... link:tests/ios/configure_ui_tests_video_recording.adoc[Configure UI
+    tests for Video Replay]
 
 .. link:tests/android/README.adoc[Android]
 ... link:tests/android/physical_devices.adoc[UI Tests on Physical Devices]
@@ -95,9 +100,12 @@
 .. link:deployments/focus_message.adoc[Release Notes]
 .. link:deployments/ios/README.adoc[iOS]
 ... link:deployments/ios/code_signing/README.adoc[Code Signing]
-.... link:deployments/ios/code_signing/upload_manually.adoc[Upload Certificates Manually]
-.... link:deployments/ios/code_signing/certificate_management.adoc[Managing Certificates and Provisioning Profiles]
-.... link:deployments/ios/code_signing/create_a_code_signing_identity.adoc[Creating a Code Signing Identity]
+.... link:deployments/ios/code_signing/upload_manually.adoc[Upload
+     Certificates Manually]
+.... link:deployments/ios/code_signing/certificate_management.adoc[Managing
+     Certificates and Provisioning Profiles]
+.... link:deployments/ios/code_signing/create_a_code_signing_identity.adoc[Creating
+     a Code Signing Identity]
 ... link:deployments/ios/itunes_connect.adoc[iTunes Connect]
 
 .. link:deployments/android/README.adoc[Android]
@@ -105,13 +113,15 @@
 .... link:deployments/android/keystores/manage.adoc[Managing Your KeyStores]
 
 ... link:deployments/android/google_play/README.adoc[Google Play]
-.... link:deployments/android/google_play/developer_console.adoc[Create a private key and setup permissions]
+.... link:deployments/android/google_play/developer_console.adoc[Create
+     a private key and setup permissions]
 .... link:deployments/android/google_play/automatic.adoc[Automatic]
 .... link:deployments/android/google_play/manual.adoc[Manual]
 
 . link:integrations/README.adoc[Integrations]
 .. link:integrations/itunes_connect.adoc[Apple Developer Portal]
-.. link:integrations/apple_2fa.adoc[Using an Apple Account with Two-Factor Authentication]
+.. link:integrations/apple_2fa.adoc[Using an Apple Account with
+   Two-Factor Authentication]
 .. link:integrations/bitbucket_pipelines.adoc[Bitbucket Pipelines]
 .. link:integrations/ccmenu.adoc[CCMenu]
 .. link:integrations/github_issues.adoc[GitHub Issues]
@@ -147,25 +157,34 @@
 .. link:billing/payment_details.adoc[Change payment details]
 
 . link:troubleshooting/README.adoc[Troubleshooting]
-.. link:troubleshooting/user_not_getting_alert_when_a_new_version_of_app_is_available.adoc[User not getting alert when a new version of app is available]
+.. link:troubleshooting/user_not_getting_alert_when_a_new_version_of_app_is_available.adoc[User
+   not getting alert when a new version of app is available]
 .. link:troubleshooting/ios/README.adoc[iOS]
 ... link:troubleshooting/ios/common_build_errors.adoc[Common iOS build errors]
 ... link:troubleshooting/ios/missing_podfilelock.adoc[Missing Podfile.lock]
 ... link:troubleshooting/ios/missing_schemes.adoc[Missing schemes]
-... link:troubleshooting/ios/getting_device_logs_from_xcode.adoc[Getting device logs from Xcode]
+... link:troubleshooting/ios/getting_device_logs_from_xcode.adoc[Getting
+    device logs from Xcode]
 ... link:troubleshooting/ios/install_builds.adoc[Installing builds]
-... link:troubleshooting/ios/spec_repo_not_compatible_with_older_cocoapods_versions.adoc[Spec repo not compatible with older CocoaPods versions]
-... link:troubleshooting/ios/install_updated_wwdr_cert.adoc[Installing Apple's Updated Intermediate WWDR Certificate]
-... link:troubleshooting/ios/core_data-generated_classes_not_found_by_xcode_8_during_the_build.adoc[Core Data generated classes not found by Xcode 8 during the build]
+... link:troubleshooting/ios/spec_repo_not_compatible_with_older_cocoapods_versions.adoc[Spec
+    repo not compatible with older CocoaPods versions]
+... link:troubleshooting/ios/install_updated_wwdr_cert.adoc[Installing
+    Apple's Updated Intermediate WWDR Certificate]
+... link:troubleshooting/ios/core_data-generated_classes_not_found_by_xcode_8_during_the_build.adoc[Core
+    Data generated classes not found by Xcode 8 during the build]
 
 .. link:troubleshooting/android/README.adoc[Android]
 ... link:troubleshooting/android/common.adoc[Common Android build errors]
-... link:troubleshooting/android/docker_environment.adoc[Tools and Platform versions for Android / Docker environment]
+... link:troubleshooting/android/docker_environment.adoc[Tools and
+    Platform versions for Android / Docker environment]
 ... link:troubleshooting/android/google_play.adoc[Google Play Errors]
-... link:troubleshooting/android/build_number_without_sdk.adoc[Displaying Build Number in an Android App without SDK Integration]
+... link:troubleshooting/android/build_number_without_sdk.adoc[Displaying
+    Build Number in an Android App without SDK Integration]
 
 .. link:troubleshooting/frameworks/README.adoc[Frameworks]
-... link:troubleshooting/frameworks/cordova_ionic.adoc[Common Cordova / Ionic build errors]
-... link:troubleshooting/frameworks/react_native.adoc[Common React Native errors]
+... link:troubleshooting/frameworks/cordova_ionic.adoc[Common Cordova /
+    Ionic build errors]
+... link:troubleshooting/frameworks/react_native.adoc[Common React
+    Native errors]
 
 . link:https://apidocs.buddybuild.com/[REST API]

--- a/_common/important-ssh_access.adoc
+++ b/_common/important-ssh_access.adoc
@@ -8,7 +8,8 @@ providers:
 - link:{{readme.path}}/../repository/gitlab/README.adoc[GitLab],
   GitLab self-hosted
 - link:{{readme.path}}/../repository/bitbucket/README.adoc[Bitbucket],
-  link:{{readme.path}}/../repository/bitbucket_server/README.adoc[Bitbucket Server]
+  link:{{readme.path}}/../repository/bitbucket_server/README.adoc[Bitbucket
+  Server]
 
 Buddybuild's integrations provide the following features:
 

--- a/builds/selective_builds.adoc
+++ b/builds/selective_builds.adoc
@@ -23,7 +23,8 @@ link:skip_a_build.adoc[Skipping a build].
 
 . Visit link:https://dashboard.buddybuild.com/[the buddybuild dashboard].
 
-. image:img/button-app_settings.png[App Settings button,118,64,role="right thumb"]
+. image:img/button-app_settings.png[App Settings
+  button,118,64,role="right thumb"]
   Click **App Settings** in the top navigation bar. The **App Settings**
   page is displayed:
 +
@@ -34,7 +35,8 @@ image:img/page-app_settings.png[App Settings page,role="frame"]
   click the **Configure** button on the right side of the row. The
   **Enable selective builds** page is displayed:
 +
-image:img/page-build_skipping-disabled.png[Enable Selective Builds page,role="frame"]
+image:img/page-build_skipping-disabled.png["Enable Selective Builds
+page", role="frame"]
 
 . image:img/button-toggle.png[Toggle button,33,16,role="right"]
   Click the toggle button to enable selective builds. One of the lower

--- a/builds/settings/README.adoc
+++ b/builds/settings/README.adoc
@@ -80,7 +80,8 @@ to any new applications that are added to buddybuild.
 
 To apply any specific setting to already-configured applications:
 
-.  image:img/button-magic_wand.png["The magic wand button", 63, 62, role="right"]
+. image:img/button-magic_wand.png["The magic wand button", 63, 62,
+  role="right"]
   Click the **magic wand** button beside the setting you want to apply
   to one or more applications. A drop-down menu appears:
 +

--- a/index.adoc
+++ b/index.adoc
@@ -64,13 +64,15 @@ link:builds/custom_build_steps.adoc[Custom Build Steps]
 [.show-more-extra]
 --
 [.popular-doc]
-.link:troubleshooting/frameworks/cordova_ionic.adoc[Common Cordova / Ionic build errors]
+.link:troubleshooting/frameworks/cordova_ionic.adoc[Common Cordova /
+Ionic build errors]
 ****
 link:troubleshooting/README.adoc[Troubleshooting]
 ➛
 link:troubleshooting/frameworks/README.adoc[Frameworks]
 ➛
-link:troubleshooting/frameworks/cordova_ionic.adoc[Common Cordova / Ionic build errors]
+link:troubleshooting/frameworks/cordova_ionic.adoc[Common Cordova /
+Ionic build errors]
 ****
 
 [.popular-doc]

--- a/integrations/slack.adoc
+++ b/integrations/slack.adoc
@@ -41,8 +41,8 @@ screen", 1280, 1024, role="frame"]
   first of the **Integrations** screens (**Apple Dev Connection**) is
   displayed:
 +
-image:img/screen-apple_dev_connection.png["The Apple Dev Connection screen", 1280,734,
-role="frame"]
+image:img/screen-apple_dev_connection.png["The Apple Dev Connection
+screen", 1280, 734, role="frame"]
 
 . image:img/button-slack.png["The Slack button", 210, 32, role="right"]
   In the left navigation, click the **Slack** button. The **Slack**

--- a/troubleshooting/README.adoc
+++ b/troubleshooting/README.adoc
@@ -6,7 +6,8 @@ have encountered, and provides solutions that could help you.
 
 == General problems
 
-- link:user_not_getting_alert_when_a_new_version_of_app_is_available.adoc[User not getting alert when a new version of app is available]
+- link:user_not_getting_alert_when_a_new_version_of_app_is_available.adoc[User
+  not getting alert when a new version of app is available]
 
 
 == Platform-specific problems
@@ -18,19 +19,34 @@ have encountered, and provides solutions that could help you.
 
 |
 - link:ios/common_build_errors.adoc[Common iOS build errors]
+
 - link:ios/missing_podfilelock.adoc[Missing Podfile.lock]
+
 - link:ios/missing_schemes.adoc[Missing schemes]
+
 - link:ios/getting_device_logs_from_xcode.adoc[Getting device logs from Xcode]
+
 - link:ios/install_builds.adoc[Installing builds]
-- link:ios/spec_repo_not_compatible_with_older_cocoapods_versions.adoc[Spec repo not compatible with older CocoaPods versions]
-- link:ios/install_updated_wwdr_cert.adoc[Installing Apple's Updated Intermediate WWDR Certificate]
-- link:ios/core_data-generated_classes_not_found_by_xcode_8_during_the_build.adoc[Core Data generated classes not found by Xcode 8 during the build]
+
+- link:ios/spec_repo_not_compatible_with_older_cocoapods_versions.adoc[Spec
+  repo not compatible with older CocoaPods versions]
+
+- link:ios/install_updated_wwdr_cert.adoc[Installing Apple's Updated
+  Intermediate WWDR Certificate]
+
+- link:ios/core_data-generated_classes_not_found_by_xcode_8_during_the_build.adoc[Core
+  Data generated classes not found by Xcode 8 during the build]
 
 |
 - link:android/common.adoc[Common Android build errors]
-- link:android/docker_environment.adoc[Tools and Platform versions for Android / Docker environment]
+
+- link:android/docker_environment.adoc[Tools and Platform versions for
+  Android / Docker environment]
+
 - link:android/google_play.adoc[Google Play Errors]
-- link:android/build_number_without_sdk.adoc[Displaying Build Number in an Android App without SDK Integration]
+
+- link:android/build_number_without_sdk.adoc[Displaying Build Number in
+  an Android App without SDK Integration]
 |===
 
 

--- a/troubleshooting/android/README.adoc
+++ b/troubleshooting/android/README.adoc
@@ -7,6 +7,11 @@ This section covers Android-specific problems and errors, and provides
 solutions:
 
 - link:common.adoc[Common Android build errors]
-- link:docker_environment.adoc[Tools and Platform versions for Android / Docker environment]
+
+- link:docker_environment.adoc[Tools and Platform versions for Android /
+  Docker environment]
+
 - link:google_play.adoc[Google Play Errors]
-- link:build_number_without_sdk.adoc[Displaying Build Number in an Android App without SDK Integration]
+
+- link:build_number_without_sdk.adoc[Displaying Build Number in an
+  Android App without SDK Integration]

--- a/troubleshooting/ios/README.adoc
+++ b/troubleshooting/ios/README.adoc
@@ -11,6 +11,9 @@ solutions:
 - link:missing_schemes.adoc[Missing schemes]
 - link:getting_device_logs_from_xcode.adoc[Getting device logs from Xcode]
 - link:install_builds.adoc[Installing builds]
-- link:spec_repo_not_compatible_with_older_cocoapods_versions.adoc[Spec repo not compatible with older CocoaPods versions]
-- link:install_updated_wwdr_cert.adoc[Installing Apple's Updated Intermediate WWDR Certificate]
-- link:core_data-generated_classes_not_found_by_xcode_8_during_the_build.adoc[Core Data generated classes not found by Xcode 8 during the build]
+- link:spec_repo_not_compatible_with_older_cocoapods_versions.adoc[Spec
+  repo not compatible with older CocoaPods versions]
+- link:install_updated_wwdr_cert.adoc[Installing Apple's Updated
+  Intermediate WWDR Certificate]
+- link:core_data-generated_classes_not_found_by_xcode_8_during_the_build.adoc[Core
+  Data generated classes not found by Xcode 8 during the build]


### PR DESCRIPTION
The line-length checking script no longer blindly ignores lines containing `image:` or `link:` macros. For a macro-containing line longer than the limit, if there is whitespace inside the limit, we should be able to wrap those lines.

This change wraps those lines that should now be wrapped.