### PR TITLE
Update debian version in docker-environment doc

### DIFF
--- a/troubleshooting/android/docker_environment.adoc
+++ b/troubleshooting/android/docker_environment.adoc
@@ -8,7 +8,7 @@ description: >
 
 == Base Image
 
-Debian GNU/Linux 8 (jessie)
+Debian GNU/Linux 9 (stretch)
 
 == Android SDK
 


### PR DESCRIPTION
We're now running Debian 9 in production. https://app.asana.com/0/467445254502483/464775056850145/f

FYI, @kevin-bb may have more updates for this doc shortly.