### PR TITLE
[WIP] Add coverage of crash reports and instant replay.

### DIFF
--- a/SUMMARY.adoc
+++ b/SUMMARY.adoc
@@ -145,6 +145,8 @@
 . link:sdk/README.adoc[buddybuild SDK]
 .. link:sdk/automatic_update.adoc[Automatic update]
 .. link:sdk/feedback_reporter.adoc[Feedback reporter]
+.. link:sdk/crash_reporter.adoc[Crash reporter]
+.. link:sdk/instant_replay.adoc[Instant replay]
 .. link:sdk/usage_tracking.adoc[Usage tracking]
 .. link:sdk/feature_settings.adoc[Feature settings]
 .. link:sdk/integration.adoc[Manual installation (iOS)]

--- a/quickstart/android/integrate_sdk.adoc
+++ b/quickstart/android/integrate_sdk.adoc
@@ -45,11 +45,28 @@ android {
 
 === Feedback Reporter
 
-With buddybuild, you simply shake the device to share feedback. Our
-feedback reporter sends graphically annotated screenshots, feedback
-notes and device metadata to your team. Integrate with GitHub, JIRA and
-Pivotal Tracker to track feedback as issues.
-link:../../sdk/feedback_reporter.adoc[Learn more.]
+With the buddybuild SDK, you simply shake the device to share feedback.
+Our feedback reporter sends graphically annotated screenshots, feedback
+notes and device metadata to your team.  Integrate with GitHub, JIRA,
+and Pivotal Tracker to track feedback as issues.
+link:../../sdk/feedback_reporter.adoc[Learn more].
+
+
+=== Crash Reporter
+
+With the buddybuild SDK, should your app crash, a crash report is sent
+to buddybuild. You can browse crash reports and dig into the details of
+each crash.
+link:../../sdk/crash_reporter.adoc[Learn more].
+
+
+=== Instant Replay
+
+No more emailing testers for repro steps. Along with each crash report,
+buddybuild also attaches a 15-second video of your testers' interactions
+with your app's UI right up to the point where it crashed -- allowing
+you to instantly see what they did to cause a crash.
+link:../../sdk/instant_replay.adoc[Learn more].
 
 
 === Automatic Update
@@ -59,7 +76,7 @@ fixed the issue you've received feedback on! It is crucial to keep your
 testers and beta users updated on the very latest builds. If a newer
 build is available, the buddybuild SDK can automatically prompt to
 install the latest version of your app.
-link:../../sdk/automatic_update.adoc[Learn more.]
+link:../../sdk/automatic_update.adoc[Learn more].
 
 
 === Usage Tracking
@@ -68,7 +85,7 @@ Know when your testers download and launch your app in real time.
 Identify who tested your app, when they launched it and what version
 they tested. Correlate this with feedback and crash reports to
 understand your customers' experience.
-link:../../sdk/usage_tracking.adoc[Learn more.]
+link:../../sdk/usage_tracking.adoc[Learn more].
 
 {% include "../../_common/warning-sdk-android-disable_for_production.adoc" %}
 

--- a/quickstart/ios/integrate_sdk.adoc
+++ b/quickstart/ios/integrate_sdk.adoc
@@ -26,20 +26,32 @@ Integrating the buddybuild SDK will increase the size of the resulting
 `.ipa` by less than 1 MB.
 ======
 
+
 === Feedback Reporter
 
-With buddybuild, you simply take a screenshot to share feedback. Our
-feedback reporter sends graphically annotated screenshots, feedback
-notes and device metadata to your team. Integrate with GitHub, JIRA and
+With the buddybuild SDK, you simply take a screenshot to share feedback.
+Our feedback reporter sends graphically annotated screenshots, feedback
+notes and device metadata to your team. Integrate with GitHub, JIRA, and
 Pivotal Tracker to track feedback as issues.
-link:../../sdk/feedback_reporter.adoc[Learn more.]
+link:../../sdk/feedback_reporter.adoc[Learn more].
+
+
+=== Crash Reporter
+
+With the buddybuild SDK, should your app crash, a crash report is sent
+to buddybuild. You can browse crash reports and dig into the details of
+each crash.
+link:../../sdk/crash_reporter.adoc[Learn more].
+
 
 === Instant Replay
 
 No more emailing testers for repro steps. Along with each crash report,
-buddybuild will also attach a 15 second video of your testers'
-interactions with your App's UI right up to the point where it crashed
--- allowing you to instantly see what they did to cause a crash.
+buddybuild also attaches a 15-second video of your testers' interactions
+with your app's UI, right up to the point where it crashed -- allowing
+you to instantly see what they did to cause a crash.
+link:../../sdk/instant_replay.adoc[Learn more].
+
 
 === Automatic Update
 
@@ -48,7 +60,8 @@ fixed the issue you've received feedback on! It is crucial to keep your
 testers and beta users updated on the very latest builds. If a newer
 build is available, the buddybuild SDK can automatically prompt to
 install the latest version of your app.
-link:../../sdk/automatic_update.adoc[Learn more.]
+link:../../sdk/automatic_update.adoc[Learn more].
+
 
 === Usage Tracking
 
@@ -56,7 +69,8 @@ Know when your testers download and launch your app in real time.
 Identify who tested your app, when they launched it and what version
 they tested. Correlate this with feedback and crash reports to
 understand your customers' experience.
-link:../../sdk/usage_tracking.adoc[Learn more.]
+link:../../sdk/usage_tracking.adoc[Learn more].
+
 
 == How to install
 

--- a/sdk/README.adoc
+++ b/sdk/README.adoc
@@ -1,8 +1,8 @@
 ---
 titletext: The buddybuild SDK collects crash reports, feedback, usage
 description: >
-  The buddybuild SDK includes a graphical user feedback reporter, a crash
-  reporting and analysis tool, automatic app updating, and usage tracking.
+  The buddybuild SDK includes a graphical user feedback reporter, crash
+  reports, instant replays, automatic app updating and usage tracking.
 ---
 = buddybuild SDK
 
@@ -14,11 +14,13 @@ with new features.
 
 This section includes the following topics:
 
-- link:automatic_update.adoc[Automatic Update]
-- link:feedback_reporter.adoc[Feedback Reporter]
-- link:usage_tracking.adoc[Usage Tracking]
-- link:feature_settings.adoc[Feature Settings]
-- link:integration.adoc[Manual Installation (iOS)]
+- link:automatic_update.adoc[Automatic update]
+- link:feedback_reporter.adoc[Feedback reporter]
+- link:crash_reporter.adoc[Crash reporter]
+- link:instant_replay.adoc[Instant replay]
+- link:usage_tracking.adoc[Usage tracking]
+- link:feature_settings.adoc[Feature settings]
+- link:integration.adoc[Manual installation (iOS)]
 - link:api.adoc[SDK API]
 
 The SDK includes a lot of functionality in a small package; including

--- a/sdk/api.adoc
+++ b/sdk/api.adoc
@@ -37,7 +37,7 @@ However, if you send out a build to a mailing list, or through
 TestFlight or the App Store we are unable to infer who they are. If you
 see 'Unknown User' this is likely the cause.
 
-Often you'll know the identity of your user, for example, after they've
+Often you know the identity of your user, for example, after they have
 logged in. You can provide buddybuild a callback to identify the current
 user.
 
@@ -75,7 +75,7 @@ BuddyBuildSDK.setup()
 ----
 --
 
-If you return an empty string, buddybuild will fall back to the original
+If you return an empty string, buddybuild falls back to the original
 behavior.
 
 == Access API keys and other variables
@@ -149,7 +149,7 @@ BuddyBuildSDK.setMetadataObject("Login Page", forKey: "CurrentState")
 ----
 --
 
-Now when your app crashes, or your users submit feedback, you'll see
+Now when your app crashes, or your users submit feedback, you can see
 this metadata when viewing the details in the dashboard.
 
 image:img/Pasted-image-at-2016_06_22-04_08-PM.png["A screen showing the

--- a/sdk/automatic_update.adoc
+++ b/sdk/automatic_update.adoc
@@ -4,14 +4,14 @@ description: >
   The buddybuild SDK's automatic update feature notifies testers with an in-app
   prompt whenever a new build is available.
 ---
-= Automatic Update
+= Automatic update
 
 Receiving feedback on old builds is pointless -- you've probably already
 fixed the issue you've received feedback on! It is crucial to keep your
 testers and beta users updated on the very latest builds.
 
-Using the buddybuild SDK, testers will receive an in-app prompt to
-install a new build once it’s been deployed.
+Using the buddybuild SDK, testers receive an in-app prompt to
+install a new build once it has been deployed.
 
 [NOTE]
 ======
@@ -25,10 +25,3 @@ install a new build once it’s been deployed.
 Once deployments have been set up, simply
 link:../quickstart/ios/integrate_sdk.adoc[integrate the buddybuild SDK]
 into your app to enable the **Automatic Update** feature.
-
-The SDK also offers several other features in addition to Automatic
-Updates. Follow the links below to learn more about you can supercharge
-your app with the buddybuild SDK.
-
-- link:feedback_reporter.adoc[Feedback Reporter]
-- link:usage_tracking.adoc[Usage Tracking]

--- a/sdk/crash_reporter.adoc
+++ b/sdk/crash_reporter.adoc
@@ -1,0 +1,33 @@
+---
+titletext: Should your app crash, a report is sent to buddybuild
+description: >
+  The buddybuild SDK crash reporter automatically sends a report should
+  your app crash. You can browse crash reports and dig into the details
+  of each crash.
+---
+= Crash reporter
+
+Once your app builds, it may still contain bugs that cause it to crash.
+Ideally, you want to discover when and how your app crashes before you
+make it publicly available.
+
+The buddybuild SDK contains a crash reporter: should your SDK-enabled
+app crash, a crash report is sent to buddybuild. This makes it easier
+for your testers, since if they encounter a crash during testing, the
+crash report is automatically created.
+
+If you enable link:instant_replay.adoc[instant replay for crash
+reports], your crash reports are accompanied by up to 15 seconds of
+video demonstrating the actions taken by the tester that lead to the
+crash.
+
+The buddybuild dashboard lets you browse crash reports and dig into the
+details of each crash. When you configure an integration with GitHub
+Issues, JIRA, Slack, Pivotal Tracker, or Asana, buddybuild can send you
+notifications for crash reports.
+
+To enable the crash reporter, follow the procedure described in
+link:feature_settings.adoc[Feature settings], and ensure that the
+**Crash reporter** setting is enabled.
+
+FIXME: Include a screenshot of a crash report.

--- a/sdk/feature_settings.adoc
+++ b/sdk/feature_settings.adoc
@@ -4,7 +4,7 @@ description: >
   Configure which buddybuild SDK features to include when
   builds are deployed from buddybuild, for both iOS and Android.
 ---
-= SDK Feature Settings
+= SDK feature settings
 
 Buddybuild lets you select which SDK features to include when builds are
 deployed from buddybuild. In order to have these features available,
@@ -53,10 +53,13 @@ screen, when not configured", 1280, 579, role="frame"]
 +
 image:img/button-install_sdk.png["The Install the buddybuild SDK
 button", 202, 42, role="right"]
-  If so, click the **Install the buddybuild SDK** button. The follow the
-  instructions for link:../quickstart/ios/integrate_sdk.adoc[iOS
-  integration], or link:../quickstart/android/integrate_sdk.adoc[Android
-  integration].
+If so, click the **Install the buddybuild SDK** button and then follow
+the instructions for link:../quickstart/ios/integrate_sdk.adoc[iOS
+integration], or link:../quickstart/android/integrate_sdk.adoc[Android
+integration].
++
+Once you have integrated the buddybuild SDK into your app, revisit this
+procedure.
 
 . If you have installed the buddybuild SDK on at least one branch, you
   see:

--- a/sdk/feedback_reporter.adoc
+++ b/sdk/feedback_reporter.adoc
@@ -5,11 +5,11 @@ description: >
   painlessly from within your mobile app. Feedback goes directly to your bug
   tracker.
 ---
-= Feedback Reporter
+= Feedback reporter
 
 Gathering feedback from your beta users can often be a clumsy process.
 Feedback from your beta users often takes a variety of forms -- emails,
-slack messages or verbal comments.
+Slack messages or verbal comments.
 
 Most of the time, the context of the feedback is not entirely clear
 without an accompanying screenshot. Taking screenshots, attaching them
@@ -35,11 +35,4 @@ captured screenshot and comment", 1500, 900]
 
 To enable this feature,
 link:../quickstart/ios/integrate_sdk.adoc[integrate the buddybuild SDK]
-into your App.
-
-The SDK also offers several other features in addition to the Visual
-Feedback Reporter. Follow the links below to learn more about you can
-**supercharge** your app with the buddybuild SDK.
-
-- link:automatic_update.adoc[Automatic Update]
-- link:usage_tracking.adoc[Usage Tracking]
+into your app.

--- a/sdk/instant_replay.adoc
+++ b/sdk/instant_replay.adoc
@@ -1,0 +1,108 @@
+---
+titletext: Automatically capture a short video leading up to a crash
+description: >
+  The buddybuild SDK instant replay captures up to 15 seconds of video,
+  demonstrating the actions that lead to a crash in your app.
+---
+= Instant replay
+
+Instant replay, when enabled, records up to 15 seconds of video taken up
+to the point where a user sends feedback (on iOS), or when your app
+crashes. Such video can be very useful in confirming the behavior in
+your app that your testers describe. For crash reports, it may be more
+important as a tester might not recall all of the interactions that led
+to the crash.
+
+With few limitations (<<differences,see below>>), instant replay records
+all user interactions with your app, including touches, swipes, keyboard
+use, etc. While recording, your users should not notice any performance
+degradation, unless your app updates the screen rapidly.
+
+To enable instant replay for crash reports, follow the procedure
+described in link:feature_settings.adoc[Feature settings], and ensure
+that both the **Crash reporter** and **Instant Replay for crash
+reports** settings are enabled.
+
+FIXME: Include a GIF/video of feedback, or a crash report.
+
+
+[[differences]]
+== Differences between instant replay on iOS and Android
+
+There are a number of differences between the instant replay
+implementations for iOS and Android. The following table identifies and
+describes those differences.
+
+[cols="1a,1a", options="header"]
+|===
+| iOS builds
+| Android builds
+
+2+^| **First launch**
+
+|
+No permissions dialog is displayed.
+
+|
+A permissions dialog appears, asking the user to allow screen recording.
+
+If the user taps **Cancel**, or touches outside of the dialog, the
+dialog is dismissed and is presented again when the main app activity is
+resumed.
+
+Buddybuild recommends that testers check the **Don't show again**
+checkbox, and then tap **Accept**.
+
+2+^| **Touches**
+
+|
+All taps, touches, holds, swipes, pinches, and spreads are captured.
+
+|
+Only touches are recorded, due to several limitations within Android and
+how the buddybuild SDK integrates with your app.
+
+2+^| **Rotations**
+
+|
+Rotations are **not** captured.
+
+|
+Rotations are captured.
+
+2+^| **Crash report uploads**
+
+|
+Crash reports are initiated when your app is relaunched after a crash
+event.
+
+|
+Crash reports begin uploading, in the background, immediately after the
+crash event.
+
+2+^| **Privacy**
+
+|
+Screen recording continues to occur while the app is in the background,
+for a maximum of 15 seconds. During this time, the screen is blacked out
+until the app comes back into the foreground.
+
+|
+Screen recording continues to occur while the app is in the background,
+for a maximum of 15 seconds. During this time, the screen is blacked out
+until the app comes back into the foreground.
+
+Android does not currently support view blocking. Keyboard activity is
+captured, including within password and other private fields.
+
+2+^| **Performance**
+
+|
+Screen recording may impact the performance of apps involving
+significant screen activity.
+
+|
+Media projection, which is very fast, is used to capture screen
+activity. There should be no noticeable performance impact.
+
+|===

--- a/sdk/integration.adoc
+++ b/sdk/integration.adoc
@@ -5,7 +5,7 @@ description: >
   from the buddybuild dashboard. However, you can install the buddybuild
   SDK manually.
 ---
-= SDK Manual Installation (iOS)
+= SDK manual installation (iOS)
 
 We highly recommend using the **automatic** buddybuild SDK integration
 right from the buddybuild dashboard.
@@ -174,5 +174,5 @@ git push
 ----
 --
 
-That's it! Your code push will be picked up by buddybuild. Subsequent
-builds of your App will now have the SDK integrated!
+That's it! Your code push is picked up by buddybuild, and subsequent builds
+of your app have the SDK integrated.

--- a/sdk/usage_tracking.adoc
+++ b/sdk/usage_tracking.adoc
@@ -4,24 +4,17 @@ description: >
   Buddybuild SDK can track the usage of your mobile app. Get precise metrics on
   how many people downloaded your mobile app and how many launched it.
 ---
-= Usage Tracking
+= Usage tracking
 
 Tracking various levels of engagement across your testers and beta users
 can be time-consuming and inaccurate.
 
 The buddybuild SDK can help track usage of your app. Get precise metrics
-on how many people downloaded your App and how many launched it.
+on how many people downloaded your app and how many launched it.
 
 image:img/Builds---Deploy-History.png[The build details page with the
 Deploy tab selected and showing Deployment history", 1500, 615]
 
 To enable this feature, simply
 link:../quickstart/ios/integrate_sdk.adoc[integrate the buddybuild SDK]
-into your App.
-
-The SDK also offers several other features in addition to Usage
-Tracking. Follow the links below to learn more about you can
-**supercharge** your app with the buddybuild SDK.
-
-- link:feedback_reporter.adoc[Feedback Reporter]
-- link:automatic_update.adoc[Automatic Update]
+into your app.


### PR DESCRIPTION
Includes a comparison of instant replay between iOS and Android:
https://app.clubhouse.io/buddybuild/story/7086/instant-replay-ios-android-comparison

Also includes punctuation + minor wording fixes throughout the SDK
chapter.

Outstanding issues include:

* A description of the feedback and crash report UIs needs to be
  included, with screenshots and animated GIFs of instant replay.

* Need to confirm current features between iOS and Android.

* Need to figure out how to include animated GIFs without incurring
  massive file sizes. Perhaps include a sample video? Either solution
  requires CSS to overlay the animated portions over static.

* Certain screenshots contain "Upgrade Now", which was recently
  adjusted.