### PR TITLE
Make the SDK update URL use HTTPS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: node_js
 os:
   - linux
 node_js:
-  - 7
+  - 8
 env:
   - PERL5LIB=/home/travis/perl5/lib/perl5
 addons:

--- a/_common/important-ssh_access.adoc
+++ b/_common/important-ssh_access.adoc
@@ -4,9 +4,9 @@ Buddybuild has first-class integrations with the following repo
 providers:
 
 - link:{{readme.path}}/quickstart/github.adoc[GitHub],
-  GitHub Enterprise
+  link:{{readme.path}}/quickstart/github_enterprise.adoc[GitHub Enterprise]
 - link:{{readme.path}}/quickstart/gitlab.adoc[GitLab],
-  GitLab self-hosted
+  link:{{readme.path}}/quickstart/gitlab_private.adoc[GitLab self-hosted]
 - link:{{readme.path}}/quickstart/bitbucket.adoc[Bitbucket],
   link:{{readme.path}}/quickstart/bitbucket_server.adoc[Bitbucket
   Server]

--- a/_common/important-ssh_access.adoc
+++ b/_common/important-ssh_access.adoc
@@ -4,9 +4,13 @@ Buddybuild has first-class integrations with the following repo
 providers:
 
 - link:{{readme.path}}/quickstart/github.adoc[GitHub],
-  link:{{readme.path}}/quickstart/github_enterprise.adoc[GitHub Enterprise]
+  link:{{readme.path}}/quickstart/github_enterprise.adoc[GitHub
+  Enterprise]
+
 - link:{{readme.path}}/quickstart/gitlab.adoc[GitLab],
-  link:{{readme.path}}/quickstart/gitlab_private.adoc[GitLab self-hosted]
+  link:{{readme.path}}/quickstart/gitlab_private.adoc[GitLab
+  self-hosted]
+
 - link:{{readme.path}}/quickstart/bitbucket.adoc[Bitbucket],
   link:{{readme.path}}/quickstart/bitbucket_server.adoc[Bitbucket
   Server]

--- a/_common/important-ssh_access.adoc
+++ b/_common/important-ssh_access.adoc
@@ -3,12 +3,12 @@
 Buddybuild has first-class integrations with the following repo
 providers:
 
-- link:{{readme.path}}/../repository/github/README.adoc[GitHub],
+- link:{{readme.path}}/quickstart/github.adoc[GitHub],
   GitHub Enterprise
-- link:{{readme.path}}/../repository/gitlab/README.adoc[GitLab],
+- link:{{readme.path}}/quickstart/gitlab.adoc[GitLab],
   GitLab self-hosted
-- link:{{readme.path}}/../repository/bitbucket/README.adoc[Bitbucket],
-  link:{{readme.path}}/../repository/bitbucket_server/README.adoc[Bitbucket
+- link:{{readme.path}}/quickstart/bitbucket.adoc[Bitbucket],
+  link:{{readme.path}}/quickstart/bitbucket_server.adoc[Bitbucket
   Server]
 
 Buddybuild's integrations provide the following features:

--- a/quickstart/ios/integrate_sdk.adoc
+++ b/quickstart/ios/integrate_sdk.adoc
@@ -125,7 +125,7 @@ Guide].
 . Run the following command:
 +
 [source,bash]
-curl -Ls tools.buddybuild.com.s3-website-us-west-2.amazonaws.com/UpdateSDK | sh
+curl -Ls https://tools.buddybuild.com.s3-website-us-west-2.amazonaws.com/UpdateSDK | sh
 
 . Commit and push the changes.
 


### PR DESCRIPTION
Also, update the SSH admonition links appearing in repo topics to point
to the repo provider topics in the Quickstart chapter.

https://app.clubhouse.io/buddybuild/story/8962/fix-sdk-update-url-to-use-https
https://app.clubhouse.io/buddybuild/story/8963/ssh-admonition-links-should-point-to-quickstart-topics