### PR TITLE
Make the SDK update link HTTP, since HTTPS not currently available.

### DIFF
--- a/quickstart/ios/integrate_sdk.adoc
+++ b/quickstart/ios/integrate_sdk.adoc
@@ -125,7 +125,7 @@ Guide].
 . Run the following command:
 +
 [source,bash]
-curl -Ls https://tools.buddybuild.com.s3-website-us-west-2.amazonaws.com/UpdateSDK | sh
+curl -Ls http://tools.buddybuild.com.s3-website-us-west-2.amazonaws.com/UpdateSDK | sh
 
 . Commit and push the changes.
 


### PR DESCRIPTION
https://app.clubhouse.io/buddybuild/story/8967/make-the-sdk-update-link-http-since-https-is-not-currently-available