### PR TITLE
Use the correct syntax for the `upload-symbols` script.

### DIFF
--- a/builds/custom_build_steps.adoc
+++ b/builds/custom_build_steps.adoc
@@ -488,7 +488,7 @@ echo "Uploading IPAs and dSYMs to Crashlytics"
 
 CRASHLYTICS_API_KEY=Your_API_key
 echo "Uploading to Fabric via command line"
-$BUDDYBUILD_WORKSPACE/Fabric.framework/upload-symbols $CRASHLYTICS_API_KEY
+$BUDDYBUILD_WORKSPACE/Fabric.framework/upload-symbols -a $CRASHLYTICS_API_KEY -p ios $BUDDYBUILD_PRODUCT_DIR
 ----
 
 . Commit the changes to your repository:


### PR DESCRIPTION
https://app.clubhouse.io/buddybuild/story/9490/use-correct-syntax-for-upload-symbols-script-in-fabric-upload-example