### PR TITLE
Remove mentions of iOS that are now redundant without Android coverage.

### DIFF
--- a/SUMMARY.adoc
+++ b/SUMMARY.adoc
@@ -24,7 +24,7 @@
 
 .. link:quickstart/select.adoc[Select a repository/app to build]
 
-.. link:quickstart/integrate_sdk.adoc[Integrate the SDK for iOS]
+.. link:quickstart/integrate_sdk.adoc[Integrate the SDK]
 .. link:quickstart/apple_developer_portal.adoc[Connect to the Apple
    Developer Portal]
 .. link:quickstart/upload_certificates.adoc[Upload your iOS
@@ -67,7 +67,7 @@
 .. link:builds/frameworks/README.adoc[Cross-platform frameworks]
 ... link:builds/frameworks/react_native/README.adoc[React Native]
 .... link:builds/frameworks/react_native/log_javascript.adoc[Log
-     JavaScript using the buddybuild SDK (iOS)]
+     JavaScript using the buddybuild SDK]
 ... link:builds/frameworks/cordova-ionic/README.adoc[Cordova / Ionic]
 ... link:builds/frameworks/meteor/README.adoc[Meteor]
 
@@ -163,7 +163,7 @@
 .. link:troubleshooting/repo_does_not_contain_all_commits.adoc[Repository
    does not contain full list of commits]
 
-.. link:troubleshooting/common_build_errors.adoc[Common iOS build errors]
+.. link:troubleshooting/common_build_errors.adoc[Common build errors]
 .. link:troubleshooting/missing_podfilelock.adoc[Missing Podfile.lock]
 .. link:troubleshooting/missing_schemes.adoc[Missing schemes]
 .. link:troubleshooting/getting_device_logs_from_xcode.adoc[Getting

--- a/_common/note-sdk-ios-app_store_deployments.adoc
+++ b/_common/note-sdk-ios-app_store_deployments.adoc
@@ -1,11 +1,11 @@
 [NOTE]
 ======
-**SDK features for iOS App Store and TestFlight Deployments**
+**SDK features for App Store and TestFlight Deployments**
 
-iOS App Store installs have all buddybuild SDK features **disabled**
+App Store installs have all buddybuild SDK features **disabled**
 except for crash reporting. The SDK determines whether an install is
-from the iOS App Store by checking the NSBundle's `appStoreReceiptURL`;
-only iOS App Store-installed apps have the URL filled in.
+from the App Store by checking the NSBundle's `appStoreReceiptURL`;
+only App Store-installed apps have the URL filled in.
 
 TestFlight builds deployed by buddybuild have all of the buddybuild SDK
 features that were enabled. If you don't want your TestFlight

--- a/builds/README.adoc
+++ b/builds/README.adoc
@@ -77,26 +77,19 @@ Here is a high-level summary of buddybuild's build process:
 
 == Details
 
-[cols="1a,1a",options="headers"]
-|===
-| For all builds
-| iOS-specific builds
-
-| link:dependencies/README.adoc[Managing dependencies] +
-  link:build_logs.adoc[Build details and logs] +
-  link:custom_build_steps.adoc[Custom build steps] +
-  link:secrets/environment_variables.adoc[Environment variables] +
-  link:secrets/secure_files.adoc[Secure files] +
-  link:pull_requests.adoc[Pull requests] +
-  link:danger.adoc[Danger] +
-  link:schedule_builds.adoc[Scheduling builds] +
-  link:skip_a_build.adoc[Skipping a build] +
-  link:auto-cancel_builds.adoc[Auto-cancel builds] +
-  link:disable_a_build.adoc[Disable a build] +
-  link:selective_builds.adoc[Selective builds]
-
-| link:secrets/device_variables.adoc[Device variables] +
-  link:xcode_versions.adoc[Xcode versions and Xcode preview] +
-  link:provisioning_profile_explorer.adoc[Provisioning profile
-  inspector]
-|===
+- link:dependencies/README.adoc[Managing dependencies]
+- link:build_logs.adoc[Build details and logs]
+- link:custom_build_steps.adoc[Custom build steps]
+- link:secrets/environment_variables.adoc[Environment variables]
+- link:secrets/secure_files.adoc[Secure files]
+- link:secrets/device_variables.adoc[Device variables]
+- link:pull_requests.adoc[Pull requests]
+- link:danger.adoc[Danger]
+- link:schedule_builds.adoc[Scheduling builds]
+- link:skip_a_build.adoc[Skipping a build]
+- link:auto-cancel_builds.adoc[Auto-cancel builds]
+- link:disable_a_build.adoc[Disable a build]
+- link:selective_builds.adoc[Selective builds]
+- link:xcode_versions.adoc[Xcode versions and Xcode preview]
+- link:provisioning_profile_explorer.adoc[Provisioning profile
+- inspector]

--- a/builds/custom_build_steps.adoc
+++ b/builds/custom_build_steps.adoc
@@ -407,7 +407,7 @@ non-zero status and the build fails.
 == Upload dSYMs to Fabric
 
 link:https://get.fabric.io/[Fabric] is a platform that helps mobile
-teams build better apps. Many iOS developers use Fabric's
+teams build better apps. Many developers use Fabric's
 link:http://try.crashlytics.com/[Crashlytics] kit to process crash
 reports. In order to use Crashlytics, the debug symbols file (dSYM) file
 needs to be uploaded.

--- a/builds/download_ipa.adoc
+++ b/builds/download_ipa.adoc
@@ -1,9 +1,8 @@
 ---
-titletext: How to download iOS build artifacts
+titletext: How to download build artifacts
 description: >
   Buddybuild automatically manages your app bundles and dSYMs securely
-  for you. Download your iOS build artifacts from a build's details
-  page.
+  for you. Download your build artifacts from a build's details page.
 ---
 = Downloading build artifacts
 

--- a/builds/frameworks/cordova-ionic/README.adoc
+++ b/builds/frameworks/cordova-ionic/README.adoc
@@ -1,11 +1,11 @@
 ---
 titletext: Native support for Cordova / Ionic apps
 description: >
-  Buddybuild supports Cordova / Ionic apps for iOS.
+  Buddybuild supports Cordova / Ionic apps.
 ---
 = Cordova / Ionic Setup
 
-Buddybuild natively supports Cordova / Ionic apps for iOS.
+Buddybuild natively supports Cordova / Ionic apps.
 
 There are three steps to make sure that your Cordova / Ionic project is
 ready to onboard onto buddybuild.

--- a/builds/frameworks/react_native/README.adoc
+++ b/builds/frameworks/react_native/README.adoc
@@ -1,11 +1,11 @@
 ---
-titletext: React Native support for iOS
+titletext: React Native support
 description: >
-  Buddybuild supports React Native for iOS.
+  Buddybuild supports React Native.
 ---
 = React Native
 
-Buddybuild natively supports React Native apps for iOS.
+Buddybuild natively supports React Native apps.
 
 There are two steps to make sure that your React Native project is ready
 to onboard onto buddybuild.

--- a/builds/frameworks/react_native/log_javascript.adoc
+++ b/builds/frameworks/react_native/log_javascript.adoc
@@ -5,7 +5,7 @@ description: >
   console.log, console.error and view them in Crash and Feedback
   reports logs.
 ---
-= Log React Native JavaScript using the buddybuild SDK (iOS)
+= Log React Native JavaScript using the buddybuild SDK
 
 The buddybuild SDK is a lightweight yet powerful
 link:../../../quickstart/integrate_sdk.adoc[suite of tools] that

--- a/builds/provisioning_profile_explorer.adoc
+++ b/builds/provisioning_profile_explorer.adoc
@@ -1,5 +1,5 @@
 ---
-titletext: Inspect provisioning profiles for a specific iOS build
+titletext: Inspect provisioning profiles for a specific build
 description: >
   Inspect a specific build to see the exact provisioning profile
   that it was built with, which devices are enabled, and view the

--- a/builds/remote_access.adoc
+++ b/builds/remote_access.adoc
@@ -6,9 +6,9 @@ description: >
 ---
 = Remote access
 
-Remote access is a feature that allows you to access a build machine via
-SSH (or screen sharing for iOS builds) while a build is under way. This
-can make diagnosing build failures much easier than scanning through log
+Remote access is a feature that allows you to access a build machine, via
+SSH or screen sharing, while a build is under way. This can make
+diagnosing build failures much easier than scanning through log
 files. Remote access can also reduce the time required to get
 link:custom_build_steps.adoc[custom build steps] working.
 
@@ -23,8 +23,7 @@ access enabled, buddybuild collects the public SSH keys stored in your
 source code repository and configures them in the build machine. Once
 the SSH configuration is complete, buddybuild provides the connection
 details so that you can connect right away. Screen sharing access is
-also provided for iOS builds, using the Virtual Network Computing
-protocol (VNC).
+also provided, using the Virtual Network Computing protocol (VNC).
 
 You can watch the build progress, tail logs, make adjustments to build
 scripts, anything that would help future builds succeed more often. You
@@ -99,7 +98,7 @@ management interface.
   public key(s) and displays the connection details. Both the SSH and
   screen sharing connection details are presented:
 +
-image:img/panel-remote_access-ios.png["An iOS build's remote access
+image:img/panel-remote_access-ios.png["A build's remote access
 connection details", 870, 226, role="frame"]
 
 . Use SSH to connect to the build VM.
@@ -131,9 +130,9 @@ changes you want to keep; nothing is saved when the VM is deleted.
 
 
 [[screenshare]]
-== Screen sharing for iOS builds
+== Screen sharing for builds
 
-Screen sharing is enabled for iOS builds when you rebuild with remote
+Screen sharing is enabled for builds when you rebuild with remote
 access, and uses the Virtual Network Computing (VNC) protocol.
 
 To use screen sharing:

--- a/builds/secrets/README.adoc
+++ b/builds/secrets/README.adoc
@@ -16,7 +16,7 @@ buddybuild provides three sets of variables that you can define:
 . link:environment_variables.adoc[Environment Variables] (made available
   to your build time scripts)
 
-. link:device_variables.adoc[Device Variables] (available your iOS app
+. link:device_variables.adoc[Device Variables] (available to your app
   at run time via the buddybuild SDK)
 
 . link:secure_files.adoc[Secure Files] (files made available to your

--- a/builds/secrets/device_variables.adoc
+++ b/builds/secrets/device_variables.adoc
@@ -14,11 +14,6 @@ checked in to your repository.
 Device variables are made available to your app during run time via the
 link:../../sdk/README.adoc[buddybuild SDK].
 
-[IMPORTANT]
-===========
-Device variables are currently only available for iOS apps.
-===========
-
 
 [[step1]]
 == Step 1: Create Device Variables in buddybuild

--- a/builds/xcode_versions.adoc
+++ b/builds/xcode_versions.adoc
@@ -1,8 +1,9 @@
 ---
-titletext: Testing iOS apps against the latest version of Xcode
+titletext: Testing your apps against the latest version of Xcode
 description: >
-  Buddybuild allows you to test your iOS apps against all version of Xcode,
-  including the latest beta versions, without having to download them locally.
+  Buddybuild allows you to test your apps against all versions of Xcode,
+  including the latest beta versions, without having to download them
+  locally.
 ---
 = Xcode Versions and Xcode Preview
 

--- a/deployments/code_signing/README.adoc
+++ b/deployments/code_signing/README.adoc
@@ -25,25 +25,25 @@ If you'd like to learn more about code signing, read on.
 
 == Certificates and Private Keys
 
-Device builds on iOS are required to be signed with a developer's
-certificate. Code signing allows iOS devices to verify the app
-developer's identity, and that the app has not been tampered with.
+Device builds are required to be signed with a developer's certificate.
+Code signing allows devices to verify the app developer's identity, and
+that the app has not been tampered with.
 
 Developer identities are tied to two artifacts -- a certificate and a
 private key that unlocks the certificate. Both these artifacts are
 probably already present if you've ever deployed builds to a device.
 
-Typically, there are two types of certificates available to iOS
-developers -- one is a development certificate used for local development
-and testing -- the other is a distribution certificate meant for builds
+Typically, there are two types of certificates available to developers
+-- one is a development certificate used for local development and
+testing -- the other is a distribution certificate meant for builds
 destined for the App Store.
 
 If you're part of the Apple Enterprise program, you also have an
 Enterprise Distribution certificate that allows you to deploy apps
 within your enterprise.
 
-You must code sign iOS applications before any iOS devices will accept
-them for installation.
+You must code sign your applications before any devices will accept them
+for installation.
 
 Buddybuild creates builds on your behalf, so we need access to your
 developer identities in order to sign builds. Managing these can be a

--- a/deployments/code_signing/create_a_code_signing_identity.adoc
+++ b/deployments/code_signing/create_a_code_signing_identity.adoc
@@ -1,8 +1,8 @@
 ---
-titletext: How to create a code signing identity for iOS apps
+titletext: How to create a code signing identity for your apps
 description: >
-  Step-by-step instructions for creating an iOS code signing
-  identity for your apps.
+  Step-by-step instructions for creating a code signing identity for
+  your apps.
 ---
 = Creating a Code Signing Identity
 

--- a/deployments/code_signing/upload_manually.adoc
+++ b/deployments/code_signing/upload_manually.adoc
@@ -1,5 +1,5 @@
 ---
-titletext: How to manually upload iOS code signing certificates
+titletext: How to manually upload code signing certificates
 description: >
   Buddybuild can manage your code signing by automatically uploading
   certificates and auto-syncing provisioning profiles, or you can do

--- a/deployments/itunes_connect.adoc
+++ b/deployments/itunes_connect.adoc
@@ -1,8 +1,8 @@
 ---
-titletext: Auto-deploy successful iOS app builds to iTunes Connect
+titletext: Auto-deploy successful app builds to iTunes Connect
 description: >
-  Buddybuild can automatically deploy successful builds to iTunes Connect in
-  order to submit your app to TestFlight or to the App Store.
+  Buddybuild can automatically deploy successful builds to iTunes
+  Connect in order to submit your app to TestFlight or to the App Store.
 ---
 = Deploy to iTunes Connect
 

--- a/index.adoc
+++ b/index.adoc
@@ -16,7 +16,7 @@ Welcome to buddybuild docs!
 [.land-subhead]
 pass:[<nobr>]Buddybuild is a pass:[<wbr/>]continuous integration (CI),
 pass:[<wbr/>]continuous deployment (CD), pass:[<wbr/>]and user feedback
-platform pass:[<wbr/>]for mobile development teams.
+platform pass:[<wbr/>]for iOS development teams.
 
 [.call-to-action]
 link:quickstart/README.adoc[Let’s begin!, role="button"]
@@ -28,16 +28,15 @@ Popular Docs
 --
 
 [.popular-doc]
-.link:troubleshooting/install_builds.adoc[Trouble installing builds on iOS]
+.link:troubleshooting/install_builds.adoc[Trouble installing builds]
 ****
 link:troubleshooting/README.adoc[Troubleshooting]
 ➛
-link:troubleshooting/install_builds.adoc[Trouble installing builds
-on iOS]
+link:troubleshooting/install_builds.adoc[Trouble installing builds]
 ****
 
 [.popular-doc]
-.link:troubleshooting/common_build_errors.adoc[Common iOS build errors]
+.link:troubleshooting/common_build_errors.adoc[Common build errors]
 ****
 link:troubleshooting/README.adoc[Troubleshooting]
 ➛

--- a/quickstart/README.adoc
+++ b/quickstart/README.adoc
@@ -30,14 +30,14 @@ based on the configuration that you have setup.
 +
 [NOTE]
 ======
-If you have multiple build targets defined for your iOS app, you need to
+If you have multiple build targets defined for your app, you need to
 complete the Quickstart process once for each target.
 ======
 
 . link:invite_testers.adoc[**Invite testers**]
 +
-This step prepares your app for deployment to your testers. For iOS
-projects, this involves uploading code signing identities.
+This step prepares your app for deployment to your testers, which
+involves uploading code signing identities.
 
 Optional additional steps include:
 

--- a/quickstart/apple_developer_portal.adoc
+++ b/quickstart/apple_developer_portal.adoc
@@ -1,5 +1,5 @@
 ---
-titletext: Invite testers to try your iOS app
+titletext: Invite testers to try your app
 description: >
   Buddybuild manages code signing and provisioning profiles complexities to
   create signed device builds, allowing you to send apps to testers easily.
@@ -16,7 +16,7 @@ If you have not done so already, link:connect/README.adoc[Sign up and
 connect buddybuild to your source control] and then
 link:select.adoc[Select a repository/app to build].
 
-. After you link:select.adoc[add an iOS app to buddybuild], you should
+. After you link:select.adoc[add an app to buddybuild], you should
   see the **Ready to try on a device** dialog:
 +
 image:img/dialog-ready_to_try_on_device.png["The Ready to try on a

--- a/quickstart/auto_versioning.adoc
+++ b/quickstart/auto_versioning.adoc
@@ -1,10 +1,10 @@
 ---
-titletext: Auto-versioning CFBundleVersion for iOS
+titletext: Auto-versioning CFBundleVersion
 description: >
-  Buddybuild can update the iOS CFBundleVersion configurable automatically,
+  Buddybuild can update the CFBundleVersion configurable automatically,
   with no repository changes required.
 ---
-= Auto-version iOS builds
+= Auto-version builds
 
 == CFBundleVersion
 

--- a/quickstart/connect/bitbucket.adoc
+++ b/quickstart/connect/bitbucket.adoc
@@ -9,10 +9,10 @@ description: >
 First things first! Let's sign up with buddybuild.
 
 Signing up with buddybuild via Bitbucket allows buddybuild to access
-your iOS apps' source code. Buddybuild associates with
-your repository, and builds your app every time a commit is pushed by
-you or your team -- ensuring that you always have a green build that you
-can deploy to your testers.
+your apps' source code. Buddybuild associates with your repository, and
+builds your app every time a commit is pushed by you or your team --
+ensuring that you always have a green build that you can deploy to your
+testers.
 
 [NOTE]
 ======

--- a/quickstart/connect/gitlab.adoc
+++ b/quickstart/connect/gitlab.adoc
@@ -9,7 +9,7 @@ description: >
 First things first! Let's sign up with buddybuild.
 
 Signing up with buddybuild via GitLab allows buddybuild to access your
-iOS apps' source code. Buddybuild associates with your repository, and
+apps' source code. Buddybuild associates with your repository, and
 builds your app every time a commit is pushed by you or your team --
 ensuring that you always have a green build that you can deploy to your
 testers.

--- a/quickstart/integrate_sdk.adoc
+++ b/quickstart/integrate_sdk.adoc
@@ -1,11 +1,11 @@
 ---
-titletext: How to integrate buddybuild's SDK for iOS
+titletext: How to integrate buddybuild's SDK
 description: >
-  Integrate the buddybuild SDK for iOS to access graphical user feedback
+  Integrate the buddybuild SDK to access graphical user feedback
   reports, crash reports, tester usage and analytics, and automatic app
   updates.
 ---
-= Integrate the buddybuild SDK for iOS
+= Integrate the buddybuild SDK
 
 == About the buddybuild SDK
 
@@ -59,9 +59,9 @@ link:../../sdk/usage_tracking.adoc[Learn more.]
 
 == How to integrate
 
-Enabling the SDK requires code changes in your iOS Application. We can
-make these changes automatically so you don't have to! Enable the
-buddybuild SDK in just four easy steps.
+Enabling the SDK requires code changes in your application. We can make
+these changes automatically so you don't have to! Enable the buddybuild
+SDK in just four easy steps.
 
 . Log in to the link:https://dashboard.buddybuild.com/[buddybuild
   dashboard]. The list of builds is displayed:

--- a/quickstart/invite_testers.adoc
+++ b/quickstart/invite_testers.adoc
@@ -1,10 +1,10 @@
 ---
-titletext: Invite testers to try your iOS app
+titletext: Invite testers to try your app
 description: >
   Buddybuild manages code signing and provisioning profiles complexities to
   create signed device builds, allowing you to send apps to testers easily.
 ---
-= Invite testers to try your iOS app
+= Invite testers to try your app
 
 If you have not already done so, complete
 link:apple_developer_portal.adoc[Connect to the Apple Developer Portal],

--- a/quickstart/tests.adoc
+++ b/quickstart/tests.adoc
@@ -1,5 +1,5 @@
 ---
-titletext: How to configure unit tests for your iOS apps
+titletext: How to configure unit tests for your apps
 description: >
   You can configure whether unit tests are executed for every build.
   Tests results are displayed in the buddybuild dashboard.
@@ -30,7 +30,7 @@ screen", 1280, 737, role="frame"]
   The **Test configuration** screen is displayed:
 +
 image:img/screen-test_configuration-ios.png["The Test configuration
-screen for iOS apps", 1280, 393, role="frame"]
+screen", 1280, 393, role="frame"]
 +
 The options available are:
 +
@@ -42,7 +42,7 @@ role="right"]
 Click the **Configure** button to access the **Run tests** screen.
 +
 image:img/screen-test_configuration-ios-virtual.png["The Run tests
-screen for iOS apps", 1280, 587, role="frame"]
+screen", 1280, 587, role="frame"]
 +
 Buddybuild maintains a pool of simulators of Apple devices, with a
 selection of iOS versions. You can select which simulators to use when

--- a/quickstart/upload_certificates.adoc
+++ b/quickstart/upload_certificates.adoc
@@ -1,20 +1,20 @@
 ---
-titletext: Invite testers to try your iOS app
+titletext: Upload your iOS certificates
 description: >
   Buddybuild manages code signing and provisioning profiles complexities to
   create signed device builds, allowing you to send apps to testers easily.
 ---
 = Upload your iOS certificates
 
-Before we can invite testers to test your iOS app, buddybuild requires
+Before we can invite testers to test your app, buddybuild requires
 your link:{{readme.path}}/deployments/code_signing/README.adoc[Code
 Signing Identities and Provisioning Profiles] to create signed device
 builds.
 
-All apps to be installed on iOS devices must be signed with a
-code-signing identity. Buddybuild cannot create a code-signing identity
-for you, you need to do that through Xcode, or the Apple Developer
-Portal. For more information, see
+All apps to be installed on devices must be signed with a code-signing
+identity. Buddybuild cannot create a code-signing identity for you, you
+need to do that through Xcode, or the Apple Developer Portal. For more
+information, see
 link:https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppDistributionGuide/MaintainingCertificates/MaintainingCertificates.html[Maintaining
 Your Signing Identities and Certificates] in Apple's documentation.
 
@@ -72,11 +72,11 @@ screen", 1280, 564, role="frame"]
 . image:img/button-invite_testers.png["The Invite testers button", 112,
   42, role="right"]
   Click the **Invite testers** button to continue with
-  link:invite_testers.adoc[Invite testers to try your iOS app].
+  link:invite_testers.adoc[Invite testers to try your app].
 
 {% include "/_common/note-device_vs_simulator_builds.adoc" %}
 
 Once the upload is complete, buddybuild has everything it needs to
 perform device builds. Now all we need is a set of emails to send these
 builds to -- continue with link:invite_testers.adoc[Invite testers to
-try your iOS app].
+try your app].

--- a/sdk/README.adoc
+++ b/sdk/README.adoc
@@ -18,7 +18,7 @@ This section includes the following topics:
 - link:feedback_reporter.adoc[Feedback Reporter]
 - link:usage_tracking.adoc[Usage Tracking]
 - link:feature_settings.adoc[Feature Settings]
-- link:integration.adoc[Manual Installation (iOS)]
+- link:integration.adoc[Manual Installation]
 - link:api.adoc[SDK API]
 
 The SDK includes a lot of functionality in a small package; including

--- a/sdk/integration.adoc
+++ b/sdk/integration.adoc
@@ -51,7 +51,7 @@ unzip BuddyBuildSDK.framework.zip
 rm -f BuddyBuildSDK.framework.zip
 ----
 
-. [[add-frameworks]] **Add iOS frameworks**
+. [[add-frameworks]] **Add frameworks**
 +
 ****
 [loweralpha]
@@ -159,6 +159,5 @@ git commit -m 'Adding buddybuild SDK'
 git push
 ----
 
-That's it! The SDK is now integrated into your iOS app, and becomes
-active in subsequent builds, including the build started by your code
-push.
+That's it! The SDK is now integrated into your app, and becomes active
+in subsequent builds, including the build started by your code push.

--- a/tests/code_coverage.adoc
+++ b/tests/code_coverage.adoc
@@ -1,10 +1,10 @@
 ---
-titletext: How to enable code coverage for your iOS apps
+titletext: How to enable code coverage for your apps
 description: >
   See what percentage of your mobile code is covered by your current
   mobile tests.
 ---
-= Code coverage for iOS apps
+= Code coverage for your apps
 
 Code coverage measures the degree to which your code is tested by a
 particular test suite.
@@ -14,7 +14,7 @@ Code coverage gives you a record of all code branches passed over by
 your tests and provides insight into exactly how much of your code base
 is being exercised during testing.
 
-Here’s how to enable code coverage for your iOS app:
+Here’s how to enable code coverage for your app:
 
 . In Xcode, from the **Product** menu, choose **Scheme -> Edit Scheme**.
 

--- a/tests/configure_ui_tests_video_recording.adoc
+++ b/tests/configure_ui_tests_video_recording.adoc
@@ -1,10 +1,10 @@
 ---
-titletext: How to record and replay videos of iOS UI tests
+titletext: How to record and replay videos of UI tests
 description: >
-  Use the buddybuild SDK to record video of your iOS UI tests as they execute,
-  and then replay them!
+  Use the buddybuild SDK to record video of your UI tests as they
+  execute, and then replay them!
 ---
-= Configure your iOS UI tests for Video Replay
+= Configure your UI tests for Video Replay
 
 The link:{{readme.path}}/quickstart/integrate_sdk.adoc[buddybuild SDK]
 is a lightweight yet powerful suite of tools that integrates seamlessly

--- a/tests/tests.adoc
+++ b/tests/tests.adoc
@@ -1,8 +1,8 @@
 ---
 titletext: Buddybuild runs your XCTest unit tests automatically
 description: >
-  For iOS apps, buddybuild automatically scans for XCTest unit tests and
-  runs them for you as part of every build! No configuration required!
+  Buddybuild automatically scans for XCTest unit tests and runs them for
+  you as part of every build! No configuration required!
 ---
 = Unit Tests
 

--- a/troubleshooting/README.adoc
+++ b/troubleshooting/README.adoc
@@ -18,7 +18,7 @@ have encountered, and provides solutions that could help you.
 - link:repo_does_not_contain_all_commits.adoc[Repository does not contain
   full list of commits]
 
-- link:common_build_errors.adoc[Common iOS build errors]
+- link:common_build_errors.adoc[Common build errors]
 
 - link:missing_podfilelock.adoc[Missing Podfile.lock]
 

--- a/troubleshooting/common_build_errors.adoc
+++ b/troubleshooting/common_build_errors.adoc
@@ -1,10 +1,10 @@
 ---
-titletext: Common iOS build errors
+titletext: Common build errors
 description: >
-  Tips and tricks for troubleshooting the most common iOS application build
+  Tips and tricks for troubleshooting the most common application build
   errors.
 ---
-= Common iOS build errors
+= Common build errors
 
 We’ve put together a quick checklist to help teams troubleshoot the most
 common causes for build failures.

--- a/troubleshooting/core_data-generated_classes_not_found_by_xcode_8_during_the_build.adoc
+++ b/troubleshooting/core_data-generated_classes_not_found_by_xcode_8_during_the_build.adoc
@@ -1,7 +1,7 @@
 ---
-titletext: Issues with iOS Xcode 8 and Core Data generated classes
+titletext: Issues with Xcode 8 and Core Data generated classes
 description: >
-  Steps to resolve iOS compile errors when Core Data-generated classes
+  Steps to resolve compile errors when Core Data-generated classes
   are not found by Xcode during the build process.
 ---
 = Core Data generated classes not found by Xcode 8 during the build

--- a/troubleshooting/install_builds.adoc
+++ b/troubleshooting/install_builds.adoc
@@ -1,13 +1,13 @@
 ---
-titletext: Troubleshoot common issues for installing builds on iOS
+titletext: Troubleshoot common issues for installing builds
 description: >
   This section covers the most common issue encountered when installing
-  builds on iOS devices.
+  builds on devices.
 ---
-= Trouble installing builds on iOS
+= Trouble installing builds
 
 Many different kinds of problems can interfere or prevent installing an
-iOS application onto a device. This page describes a process for
+application onto a device. This page describes a process for
 determining where the problem likely lies, and provides solutions for
 the most common issues.
 
@@ -32,7 +32,7 @@ the most common issues.
 [[no_build_available]]
 == No build available to download
 
-Installing an iOS app on a particular device requires that the app is
+Installing an app on a particular device requires that the app is
 properly signed. If you have not yet uploaded a
 link:{{readme.path}}/deployments/code_signing/README.adoc[code signing
 certificate], buddybuild cannot properly sign your application.
@@ -59,9 +59,9 @@ In particular, buddybuild **cannot install on top of an App Store
 version**. Please delete any App Store versions before attempting to
 install an app through buddybuild.
 
-Also, when there are pending (or active) iOS updates, it appears that
-app installs are blocked. Make sure that your device is fully updated
-before attempting an app install.
+Also, when there are pending (or active) updates, it appears that app
+installs are blocked. Make sure that your device is fully updated before
+attempting an app install.
 
 
 [[unable_to_download]]

--- a/troubleshooting/missing_schemes.adoc
+++ b/troubleshooting/missing_schemes.adoc
@@ -1,5 +1,5 @@
 ---
-titletext: How to troubleshoot missing schemes for iOS builds
+titletext: How to troubleshoot missing schemes
 description: >
   A scheme ties together a target with a build configuration. This
   section describes how to ensure that you are not missing any schemes.


### PR DESCRIPTION
https://app.clubhouse.io/buddybuild/story/9492/remove-now-redundant-mentions-of-ios