### PR TITLE
Fix a broken link to the manual steps for SDK integration.

### DIFF
--- a/quickstart/integrate_sdk.adoc
+++ b/quickstart/integrate_sdk.adoc
@@ -128,8 +128,8 @@ Developer account] with buddybuild.
 ======
 **Prefer to manually integrate the SDK?**
 
-Follow the link:../../sdk/integration.adoc[Manual SDK Integration
-Guide].
+Follow the link:{{readme.path}}/sdk/integration.adoc[Manual SDK
+Integration guide].
 ======
 
 [[update]]


### PR DESCRIPTION
https://app.clubhouse.io/buddybuild/story/9496/fix-the-broken-link-to-manual-sdk-integration