### PR TITLE
Update switch ruby example to ruby that exists by default

### DIFF
--- a/builds/dependencies/ruby.adoc
+++ b/builds/dependencies/ruby.adoc
@@ -34,10 +34,10 @@ command in the `buddybuild_postclone.sh` script:
 ----
 #!/usr/bin/env bash
 
-chruby 2.3.1
+chruby 2.5.1
 ----
 
-This example switches the current `ruby` to version 2.3.1.
+This example switches the current `ruby` to version 2.5.1.
 
 
 [[install]]


### PR DESCRIPTION
The switch example uses a version of ruby we don't have by default anymore. Switch to 2.5.1 as we do have that one.